### PR TITLE
Move auto select panel to only when in script

### DIFF
--- a/addons/script-dock/plugin.cfg
+++ b/addons/script-dock/plugin.cfg
@@ -2,6 +2,6 @@
 
 name="script-dock"
 description="Moves the script list from ScriptEditor to a dock. This increases the available horizontal space for the ScriptEditor, and allows you to make the list a floating window."
-author="Koliur Rahman"
+author="dugramen"
 version=""
 script="plugin.gd"

--- a/addons/script-dock/plugin.cfg
+++ b/addons/script-dock/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
 name="script-dock"
-description=""
-author=""
+description="Moves the script list from ScriptEditor to a dock. This increases the available horizontal space for the ScriptEditor, and allows you to make the list a floating window."
+author="Koliur Rahman"
 version=""
 script="plugin.gd"

--- a/addons/script-dock/plugin.gd
+++ b/addons/script-dock/plugin.gd
@@ -32,11 +32,6 @@ func script_visibility_changed(a = null):
 		return
 	var parent: TabContainer = control.get_parent()
 	parent.current_tab = control.get_index()
-	 
-func on_script_changed(scr: Script):
-	if !script_editor.visible:
-		return
-	 
 
 func _exit_tree():
 	panel.reparent(default_parent)

--- a/addons/script-dock/plugin.gd
+++ b/addons/script-dock/plugin.gd
@@ -27,7 +27,9 @@ func _enter_tree():
 	
 	
  
-func script_visibility_changed():
+func script_visibility_changed(a = null):
+	if !script_editor.is_visible_in_tree():
+		return
 	var parent: TabContainer = control.get_parent()
 	parent.current_tab = control.get_index()
 	 

--- a/addons/script-dock/plugin.gd
+++ b/addons/script-dock/plugin.gd
@@ -3,26 +3,41 @@ extends EditorPlugin
 
 var control := MarginContainer.new()
 var panel: Control
-var default_parent: Control
+var default_parent: Control 
 
+
+var script_editor :ScriptEditor = null
 func _enter_tree():
-	var script_editor := EditorInterface.get_script_editor()
+	script_editor = EditorInterface.get_script_editor()
 	script_editor.editor_script_changed.connect(on_script_changed)
-	
+	script_editor.visibility_changed.connect(script_visibility_changed)
+	 
 	default_parent = script_editor.get_child(0).get_child(1)
 	panel = default_parent.get_child(0)
 	panel.reparent(control)
+	
 	
 	control.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	control.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	control.name = "Scripts"
 	add_control_to_dock(EditorPlugin.DOCK_SLOT_LEFT_BR, control)
-
-func on_script_changed(scr: Script):
+	
+	var parent: TabContainer = control.get_parent()
+	parent.print_tree()
+	
+	
+ 
+func script_visibility_changed():
 	var parent: TabContainer = control.get_parent()
 	parent.current_tab = control.get_index()
+	 
+func on_script_changed(scr: Script):
+	if !script_editor.visible:
+		return
+	 
 
 func _exit_tree():
 	panel.reparent(default_parent)
 	default_parent.move_child(panel, 0)
 	remove_control_from_docks(control)
+ 

--- a/addons/script-dock/plugin.gd
+++ b/addons/script-dock/plugin.gd
@@ -9,7 +9,7 @@ var default_parent: Control
 var script_editor :ScriptEditor = null
 func _enter_tree():
 	script_editor = EditorInterface.get_script_editor()
-	script_editor.editor_script_changed.connect(on_script_changed)
+	script_editor.editor_script_changed.connect(script_visibility_changed)
 	script_editor.visibility_changed.connect(script_visibility_changed)
 	 
 	default_parent = script_editor.get_child(0).get_child(1)


### PR DESCRIPTION
Changed that the Script tab is only active when you are in script manage.
I found it a pain to keep swapping to scene tree when I open scene with scripts.

Also update the addons/script-dock/plugin.cfg