### PR TITLE
Select scene tab if in 2D or 3D or othere 

### DIFF
--- a/addons/script-dock/plugin.gd
+++ b/addons/script-dock/plugin.gd
@@ -7,7 +7,10 @@ var default_parent: Control
 var script_editor :ScriptEditor = null
 var last_screen:=''
 
+ 
+
 func _enter_tree()->void:
+	#print(" current screen " ,get_main_screen())
 	script_editor = EditorInterface.get_script_editor()
 	script_editor.editor_script_changed.connect(script_visibility_changed)
 	script_editor.visibility_changed.connect(script_visibility_changed)
@@ -20,9 +23,12 @@ func _enter_tree()->void:
 	control.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	control.name = "Scripts"
 	add_control_to_dock(EditorPlugin.DOCK_SLOT_LEFT_BR, control)
+	 
 	## connect to what screen is active 
 	main_screen_changed.connect(screen_changed)
-	
+	 
+		
+
 func screen_changed(screen)->void:
 	last_screen = screen
 	if !script_editor && !script_editor.is_visible_in_tree():
@@ -41,7 +47,7 @@ func script_visibility_changed(a = null)->void:
 		return
 	
 	if last_screen=="":
-		last_screen="Script"
+		return
 		
 	if last_screen=="Script":
 		var parent: TabContainer = control.get_parent()

--- a/addons/script-dock/plugin.gd
+++ b/addons/script-dock/plugin.gd
@@ -3,11 +3,11 @@ extends EditorPlugin
 
 var control := MarginContainer.new()
 var panel: Control
-var default_parent: Control 
-
-
+var default_parent: Control  
 var script_editor :ScriptEditor = null
-func _enter_tree():
+var last_screen:=''
+
+func _enter_tree()->void:
 	script_editor = EditorInterface.get_script_editor()
 	script_editor.editor_script_changed.connect(script_visibility_changed)
 	script_editor.visibility_changed.connect(script_visibility_changed)
@@ -16,22 +16,36 @@ func _enter_tree():
 	panel = default_parent.get_child(0)
 	panel.reparent(control)
 	
-	
 	control.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	control.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	control.name = "Scripts"
 	add_control_to_dock(EditorPlugin.DOCK_SLOT_LEFT_BR, control)
+	## connect to what screen is active 
+	main_screen_changed.connect(screen_changed)
 	
-	var parent: TabContainer = control.get_parent()
-	parent.print_tree()
-	
-	
- 
-func script_visibility_changed(a = null):
-	if !script_editor.is_visible_in_tree():
+func screen_changed(screen)->void:
+	last_screen = screen
+	if !script_editor && !script_editor.is_visible_in_tree():
 		return
 	var parent: TabContainer = control.get_parent()
-	parent.current_tab = control.get_index()
+	
+	match screen:
+		"Script":
+			parent.current_tab = control.get_index()
+		_:
+			parent.current_tab = 0
+			
+ 
+func script_visibility_changed(a = null)->void:
+	if !script_editor && !script_editor.is_visible_in_tree():
+		return
+	
+	if last_screen=="":
+		last_screen="Script"
+		
+	if last_screen=="Script":
+		var parent: TabContainer = control.get_parent()
+		parent.current_tab = control.get_index()
 
 func _exit_tree():
 	panel.reparent(default_parent)


### PR DESCRIPTION
Make the script tab only active if the user is in the script screen.
First load cannot get current screen have to wait on user but it make a big difference that you do not need to select scene tab every time you in 3D and opening a scene 

